### PR TITLE
Add lock-related endpoints

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ uvloop==0.16.0
 watchgod==0.7
 websockets==8.1
 
-ds-caselaw-marklogic-api-client>=4.9.1
+ds-caselaw-marklogic-api-client>=4.9.2
 # ../ds-caselaw-custom-api-client
 certifi==2021.10.8
 # charset-normalizer==2.1.0

--- a/script/test
+++ b/script/test
@@ -1,2 +1,2 @@
 export $(cat .env|xargs)
-PYTHONPATH=src pytest tests
+PYTHONPATH=src pytest tests $*

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [flake8]
 max-line-length = 120
 exclude = .tox,.git,*/migrations/*,*/static/CACHE/*,docs,node_modules,venv
-ignore = I001, I002, I003, I004
+ignore = I001, I002, I003, I004, I005
 
 [pycodestyle]
 max-line-length = 120

--- a/src/openapi_server/apis/writing_api.py
+++ b/src/openapi_server/apis/writing_api.py
@@ -19,7 +19,7 @@ from fastapi import (  # noqa: F401
     status,
 )
 from openapi_server.connect import client_for_basic_auth
-from openapi_server.models.extra_models import TokenModel  # noqa: F401
+from openapi_server.models.extra_models import TokenModel
 from openapi_server.security_api import get_token_basic
 
 router = APIRouter()
@@ -28,7 +28,9 @@ router = APIRouter()
 @router.get(
     "/lock/{judgmentUri:path}",
     responses={
-        204: {"description": "Lock state included in header"},
+        200: {
+            "description": "Lock state included in X-Locked header; annotating in X-Lock-Annotation header."
+        },
     },
     tags=["Writing"],
     summary="Query lock status for a document",
@@ -56,8 +58,12 @@ async def judgment_uri_lock_get(
 
 @router.put(
     "/lock/{judgmentUri:path}",
+    status_code=201,
     responses={
-        201: {"description": "A single judgment document, in Akoma Ntoso XML"},
+        201: {
+            "description": "The lock has been created. Returns the locked judgment's Akoma Ntoso XML",
+            "content": {"application/xml": {}},
+        },
         403: {"description": "The document was already locked by another client"},
     },
     tags=["Writing"],
@@ -133,14 +139,14 @@ async def judgment_uri_metadata_patch(
 @router.patch(
     "/judgment/{judgmentUri:path}",
     responses={
-        204: {
-            "description": "The document was updated successfully and any client lock released"
+        200: {
+            "description": "The document was updated successfully and the lock released if `unlock` is true"
         },
         400: {
             "description": "The request was malformed, and the document was not modified"
         },
         412: {
-            "description": """The document was not updated, as it has changed since
+            "description": """Not yet implemented: The document was not updated, as it has changed since
             the version number specified If-Match. To avoid this, the client should
             lock the document before making any changes to it."""
         },

--- a/tests/test_writing_api.py
+++ b/tests/test_writing_api.py
@@ -1,86 +1,202 @@
 # coding: utf-8
 
-import pytest
-
 from fastapi.testclient import TestClient
+from openapi_server.main import app
+from unittest.mock import patch, Mock
+from caselawclient.Client import (
+    MarklogicUnauthorizedError,
+    MarklogicResourceLockedError,
+    MarklogicCheckoutConflictError,
+    MarklogicResourceNotCheckedOutError,
+)
+
+# Read Lock Status (GET /lock/...)
 
 
-@pytest.mark.xfail(reason="Test is TODO")
-def test_judgment_uri_lock_get(client: TestClient):
-    """Test case for judgment_uri_lock_get
+@patch("openapi_server.apis.writing_api.client_for_basic_auth")
+def test_get_lock_no_response(mocked_client):
+    mocked_client.return_value.get_judgment_checkout_status_message.return_value = None
+    response = TestClient(app).request(
+        "GET", "/lock/judgment/uri", auth=("user", "pass")
+    )
+    mocked_client.return_value.get_judgment_checkout_status_message.assert_called_with(
+        "judgment/uri"
+    )
+    assert response.status_code == 200
+    assert response.headers["X-Locked"] == "0"
+    assert "Not locked" in response.text
 
-    Query lock status for a document
-    """
 
-    headers = {
-        "Authorization": "BasicZm9vOmJhcg==",
-    }
-    response = client.request(
-        "GET",
-        "/{judgmentUri}/lock".format(judgmentUri="judgment_uri_example"),
-        headers=headers,
+@patch("openapi_server.apis.writing_api.client_for_basic_auth")
+def test_get_lock_locked(mocked_client):
+    mocked_client.return_value.get_judgment_checkout_status_message.return_value = (
+        "kitten"
+    )
+    response = TestClient(app).request(
+        "GET", "/lock/judgment/uri", auth=("user", "pass")
     )
 
-    # uncomment below to assert the status code of the HTTP response
-    assert response.status_code == 200
-
-
-@pytest.mark.xfail(reason="Test is TODO")
-def test_judgment_uri_lock_put(client: TestClient):
-    """Test case for judgment_uri_lock_put
-
-    Lock access to a document
-    """
-
-    headers = {
-        "Authorization": "BasicZm9vOmJhcg==",
-    }
-    response = client.request(
-        "PUT",
-        "/{judgmentUri}/lock".format(judgmentUri="judgment_uri_example"),
-        headers=headers,
+    mocked_client.return_value.get_judgment_checkout_status_message.assert_called_with(
+        "judgment/uri"
     )
-
-    # uncomment below to assert the status code of the HTTP response
     assert response.status_code == 200
+    assert response.headers["X-Locked"] == "1"
+    assert response.headers["X-Lock-Annotation"] == "kitten"
+    assert "kitten" in response.text
 
 
-@pytest.mark.xfail(reason="Test is TODO")
-def test_judgment_uri_metadata_patch(client: TestClient):
-    """Test case for judgment_uri_metadata_patch
+@patch("openapi_server.apis.writing_api.client_for_basic_auth")
+def test_get_lock_unauthorised(mocked_client):
+    # More generally testing errors are passed through from the client
+    mocked_client.return_value.get_judgment_checkout_status_message.side_effect = Mock(
+        side_effect=MarklogicUnauthorizedError()
+    )
+    response = TestClient(app).request(
+        "GET", "/lock/judgment/uri", auth=("user", "pass")
+    )
+    mocked_client.return_value.get_judgment_checkout_status_message.assert_called_with(
+        "judgment/uri"
+    )
+    assert response.status_code == 401
+    assert "credentials are not valid" in response.text
 
-    Set document properties
-    """
 
-    headers = {
-        "Authorization": "BasicZm9vOmJhcg==",
-    }
-    response = client.request(
+# Acquire Lock (PUT /lock/...)
+
+
+@patch("openapi_server.apis.writing_api.client_for_basic_auth")
+def test_put_lock_success(mocked_client):
+    # Checkout Judgment fails with an error or returns None
+    mocked_client.return_value.checkout_judgment.return_value = None
+    mocked_client.return_value.get_judgment_xml.return_value = b"<judgment></judgment>"
+    response = TestClient(app).request(
+        "PUT", "/lock/judgment/uri", auth=("user", "pass")
+    )
+    mocked_client.return_value.checkout_judgment.assert_called_with(
+        "judgment/uri", "Judgment locked for editing by user", False
+    )
+    assert response.status_code == 201
+    assert "<judgment>" in response.text
+
+
+@patch("openapi_server.apis.writing_api.client_for_basic_auth")
+def test_put_lock_success_temporary(mocked_client):
+    """If expires is passed, the lock will expire"""
+    mocked_client.return_value.checkout_judgment.return_value = None
+    mocked_client.return_value.get_judgment_xml.return_value = b"<judgment></judgment>"
+    response = TestClient(app).request(
+        "PUT", "/lock/judgment/uri", auth=("user", "pass"), params={"expires": "1"}
+    )
+    mocked_client.return_value.checkout_judgment.assert_called_with(
+        "judgment/uri", "Judgment locked for editing by user", True
+    )
+    assert response.status_code == 201
+    assert "<judgment>" in response.text
+
+
+@patch("openapi_server.apis.writing_api.client_for_basic_auth")
+def test_put_lock_failure(mocked_client):
+    # Checkout Judgment fails with an error or returns None
+    mocked_client.return_value.checkout_judgment.side_effect = Mock(
+        side_effect=MarklogicResourceLockedError()
+    )
+    # mocked_client.return_value.get_judgment_xml.return_value = b'<judgment></judgment>'
+    response = TestClient(app).request(
+        "PUT", "/lock/judgment/uri", auth=("user", "pass")
+    )
+    mocked_client.return_value.checkout_judgment.assert_called_with(
+        "judgment/uri", "Judgment locked for editing by user", False
+    )
+    assert response.status_code == 409
+    assert "resource is locked by another user" in response.text
+
+
+# Remove Lock (DELETE /lock/...)
+
+
+@patch("openapi_server.apis.writing_api.client_for_basic_auth")
+def test_delete_lock_success(mocked_client):
+    # Checkout Judgment fails with an error or returns None
+    mocked_client.return_value.checkin_judgment.return_value = None
+    response = TestClient(app).request(
+        "DELETE", "/lock/judgment/uri", auth=("user", "pass")
+    )
+    mocked_client.return_value.checkin_judgment.assert_called_with(
+        judgment_uri="judgment/uri"
+    )
+    assert response.status_code == 200
+    assert "unlocked" in response.text
+
+
+@patch("openapi_server.apis.writing_api.client_for_basic_auth")
+def test_delete_lock_failure(mocked_client):
+    # Checkout Judgment fails with an error or returns None
+    mocked_client.return_value.checkin_judgment.side_effect = Mock(
+        side_effect=MarklogicCheckoutConflictError()
+    )
+    response = TestClient(app).request(
+        "DELETE", "/lock/judgment/uri", auth=("user", "pass")
+    )
+    mocked_client.return_value.checkin_judgment.assert_called_with(
+        judgment_uri="judgment/uri"
+    )
+    assert response.status_code == 409
+    assert "checked out by another user" in response.text
+
+
+# Update Judgment (with lock) (PATCH /judgment/...)
+
+
+@patch("openapi_server.apis.writing_api.client_for_basic_auth")
+def test_update_judgment_annotation_ok(mocked_client):
+    # Checkout Judgment fails with an error or returns None
+    mocked_client.return_value.save_locked_judgment_xml.return_value = None
+    response = TestClient(app).request(
         "PATCH",
-        "/{judgmentUri}/metadata".format(judgmentUri="judgment_uri_example"),
-        headers=headers,
+        "/judgment/is-a-judgment/uri",
+        auth=("user", "pass"),
+        data="<judgment></judgment>",
+        params={"annotation": "hey"},
     )
-
-    # uncomment below to assert the status code of the HTTP response
-    assert response.status_code == 200
-
-
-@pytest.mark.xfail(reason="Test is TODO")
-def test_judgment_uri_put(client: TestClient):
-    """Test case for judgment_uri_put
-
-    Update a judgment
-    """
-
-    headers = {
-        "if_match": "1",
-        "Authorization": "BasicZm9vOmJhcg==",
-    }
-    response = client.request(
-        "PUT",
-        "/{judgmentUri}".format(judgmentUri="judgment_uri_example"),
-        headers=headers,
+    mocked_client.return_value.save_locked_judgment_xml.assert_called_with(
+        "is-a-judgment/uri", b"<judgment></judgment>", "hey"
     )
-
-    # uncomment below to assert the status code of the HTTP response
     assert response.status_code == 200
+    assert "not unlocked" in response.text
+
+
+@patch("openapi_server.apis.writing_api.client_for_basic_auth")
+def test_update_judgment_unlock_ok(mocked_client):
+    # Checkout Judgment fails with an error or returns None
+    mocked_client.return_value.save_locked_judgment_xml.return_value = None
+    response = TestClient(app).request(
+        "PATCH",
+        "/judgment/is-a-judgment/uri",
+        auth=("user", "pass"),
+        data="<judgment></judgment>",
+        params={"unlock": "1"},
+    )
+    mocked_client.return_value.save_locked_judgment_xml.assert_called_with(
+        "is-a-judgment/uri", b"<judgment></judgment>", ""
+    )
+    assert response.status_code == 200
+    assert "Uploaded and unlocked" in response.text
+
+
+@patch("openapi_server.apis.writing_api.client_for_basic_auth")
+def test_update_judgment_fail(mocked_client):
+    # Checkout Judgment fails with an error or returns None
+    mocked_client.return_value.save_locked_judgment_xml.side_effect = Mock(
+        side_effect=MarklogicResourceNotCheckedOutError()
+    )
+    response = TestClient(app).request(
+        "PATCH",
+        "/judgment/is-a-judgment/uri",
+        auth=("user", "pass"),
+        data="<judgment></judgment>",
+    )
+    mocked_client.return_value.save_locked_judgment_xml.assert_called_with(
+        "is-a-judgment/uri", b"<judgment></judgment>", ""
+    )
+    assert response.status_code == 409
+    assert "request needed a checkout first" in response.text


### PR DESCRIPTION
New endpoints: DELETE /lock and PATCH /judgment
Add testing for all current endpoints
Use the new error message support in the api-client
