### PR TITLE
Healthcheck endpoint

### DIFF
--- a/src/openapi_server/apis/status_api.py
+++ b/src/openapi_server/apis/status_api.py
@@ -45,6 +45,9 @@ async def status_get(
     """A test endpoint that can be used by clients to verify service availability,
     and to verify valid authentication credentials. Authentication is not required,
     but if it is provided, it will be checked for validity."""
+
+    if not token_basic.username:
+        return "/status: no username"
     client = client_for_basic_auth(token_basic)
 
     try:

--- a/src/openapi_server/apis/status_api.py
+++ b/src/openapi_server/apis/status_api.py
@@ -50,9 +50,9 @@ async def status_get(
     if not username:
         return "/status: no username"
     client = client_for_basic_auth(token_basic)
-
     try:
-        client.user_can_view_unpublished_judgments(username)
+        view_unpublished = client.user_can_view_unpublished_judgments(username)
     except MarklogicUnauthorizedError:
         raise HTTPException(status_code=401, detail=f"/status: {username} Unauthorised")
-    return f"/status: {username} Authorised"
+
+    return f"/status: {username} Authorised, and can{'not' if not view_unpublished else ''} view unpublished judgments"

--- a/src/openapi_server/apis/status_api.py
+++ b/src/openapi_server/apis/status_api.py
@@ -45,15 +45,14 @@ async def status_get(
     """A test endpoint that can be used by clients to verify service availability,
     and to verify valid authentication credentials. Authentication is not required,
     but if it is provided, it will be checked for validity."""
+    username = token_basic.username
 
-    if not token_basic.username:
+    if not username:
         return "/status: no username"
     client = client_for_basic_auth(token_basic)
 
     try:
-        search_response = client.advanced_search(only_unpublished=True)  # noqa: F841
+        client.user_can_view_unpublished_judgments(username)
     except MarklogicUnauthorizedError:
-        raise HTTPException(
-            status_code=401, detail=f"/status: {token_basic.username} Unauthorised"
-        )
-    return f"/status: {token_basic.username} Authorised"
+        raise HTTPException(status_code=401, detail=f"/status: {username} Unauthorised")
+    return f"/status: {username} Authorised"

--- a/tests/test_status_api.py
+++ b/tests/test_status_api.py
@@ -6,6 +6,11 @@ from openapi_server.main import app
 from caselawclient.Client import MarklogicUnauthorizedError
 
 
+def test_get_status_no_auth():
+    response = TestClient(app).request("GET", "/status", auth=("", ""))
+    assert response.status_code == 200
+
+
 @patch("openapi_server.apis.status_api.client_for_basic_auth")
 def test_get_status_unauthorised(mocked_client=None):
     mocked_client.return_value.advanced_search.side_effect = Mock(

--- a/tests/test_status_api.py
+++ b/tests/test_status_api.py
@@ -12,7 +12,7 @@ def test_get_status_no_auth():
 
 
 @patch("openapi_server.apis.status_api.client_for_basic_auth")
-def test_get_status_no_user(mocked_client=None):
+def test_get_status_no_such_user(mocked_client=None):
     mocked_client.return_value.user_can_view_unpublished_judgments.side_effect = Mock(
         side_effect=MarklogicUnauthorizedError()
     )
@@ -46,4 +46,18 @@ def test_get_status_less_authorised(mocked_client):
     assert "/status: user Authorised, and cannot view" in response.text
     mocked_client.return_value.user_can_view_unpublished_judgments.assert_called_with(
         "user"
+    )
+
+
+@patch("openapi_server.apis.status_api.client_for_basic_auth")
+def test_healthcheck(mocked_client):
+    mocked_client.return_value.user_can_view_unpublished_judgments.side_effect = Mock(
+        side_effect=MarklogicUnauthorizedError()
+    )
+
+    response = TestClient(app).request("GET", "/healthcheck")
+    assert response.status_code == 200
+    assert "/healthcheck: Marklogic OK" in response.text
+    mocked_client.return_value.user_can_view_unpublished_judgments.assert_called_with(
+        ""
     )

--- a/tests/test_status_api.py
+++ b/tests/test_status_api.py
@@ -31,7 +31,7 @@ def test_get_status_authorised(mocked_client):
 
     response = TestClient(app).request("GET", "/status", auth=("user", "pass"))
     assert response.status_code == 200
-    assert response.content == b'"/status: user Authorised"'
+    assert "/status: user Authorised, and can view" in response.text
     mocked_client.return_value.user_can_view_unpublished_judgments.assert_called_with(
         "user"
     )
@@ -43,7 +43,7 @@ def test_get_status_less_authorised(mocked_client):
 
     response = TestClient(app).request("GET", "/status", auth=("user", "pass"))
     assert response.status_code == 200
-    assert response.content == b'"/status: user Authorised"'
+    assert "/status: user Authorised, and cannot view" in response.text
     mocked_client.return_value.user_can_view_unpublished_judgments.assert_called_with(
         "user"
     )

--- a/tests/test_status_api.py
+++ b/tests/test_status_api.py
@@ -32,6 +32,7 @@ def test_get_status_authorised(mocked_client):
     response = TestClient(app).request("GET", "/status", auth=("user", "pass"))
     assert response.status_code == 200
     assert "/status: user Authorised, and can view" in response.text
+    assert response.headers["X-Read-Unpublished"] == "1"
     mocked_client.return_value.user_can_view_unpublished_judgments.assert_called_with(
         "user"
     )
@@ -44,6 +45,7 @@ def test_get_status_less_authorised(mocked_client):
     response = TestClient(app).request("GET", "/status", auth=("user", "pass"))
     assert response.status_code == 200
     assert "/status: user Authorised, and cannot view" in response.text
+    assert response.headers["X-Read-Unpublished"] == "0"
     mocked_client.return_value.user_can_view_unpublished_judgments.assert_called_with(
         "user"
     )

--- a/tests/test_status_api.py
+++ b/tests/test_status_api.py
@@ -12,22 +12,38 @@ def test_get_status_no_auth():
 
 
 @patch("openapi_server.apis.status_api.client_for_basic_auth")
-def test_get_status_unauthorised(mocked_client=None):
-    mocked_client.return_value.advanced_search.side_effect = Mock(
+def test_get_status_no_user(mocked_client=None):
+    mocked_client.return_value.user_can_view_unpublished_judgments.side_effect = Mock(
         side_effect=MarklogicUnauthorizedError()
     )
     response = TestClient(app).request("GET", "/status", auth=("user", "pass"))
     assert response.status_code == 401
     assert response.content == b'{"detail":"/status: user Unauthorised"}'
-    mocked_client.return_value.advanced_search.assert_called_with(only_unpublished=True)
+    mocked_client.return_value.user_can_view_unpublished_judgments.assert_called_with(
+        "user"
+    )
     # TODO: This will break when only_published becomes silently false.
 
 
 @patch("openapi_server.apis.status_api.client_for_basic_auth")
 def test_get_status_authorised(mocked_client):
-    mocked_client.return_value.advanced_search.return_value = "Not an error"
+    mocked_client.return_value.user_can_view_unpublished_judgments.return_value = True
 
     response = TestClient(app).request("GET", "/status", auth=("user", "pass"))
     assert response.status_code == 200
     assert response.content == b'"/status: user Authorised"'
-    mocked_client.return_value.advanced_search.assert_called_with(only_unpublished=True)
+    mocked_client.return_value.user_can_view_unpublished_judgments.assert_called_with(
+        "user"
+    )
+
+
+@patch("openapi_server.apis.status_api.client_for_basic_auth")
+def test_get_status_less_authorised(mocked_client):
+    mocked_client.return_value.user_can_view_unpublished_judgments.return_value = False
+
+    response = TestClient(app).request("GET", "/status", auth=("user", "pass"))
+    assert response.status_code == 200
+    assert response.content == b'"/status: user Authorised"'
+    mocked_client.return_value.user_can_view_unpublished_judgments.assert_called_with(
+        "user"
+    )


### PR DESCRIPTION
Allow /status to 200 if no username provided
Move to using `user_can_view_unpublished` and provide info in the status message.
Add a healthcheck endpoint that 200s if we can see Marklogic.