### PR TITLE
Release the latest code to production when a new `latest` tag is created

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,18 @@
+name: Release latest code for production deploy
+on:
+  release:
+    types: [published]
+
+jobs:
+  run:
+    name: Run local action
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Checkout repository
+        uses: actions/checkout@master
+      - name: Run latest-tag
+        uses: dxw/latest-tag@force-branch
+        with:
+          tag-name: production
+          force-branch: true

--- a/README.md
+++ b/README.md
@@ -32,3 +32,23 @@ Run `script/test`
 ## Linting
 
 Run `pre-commit install` to set up linting, and/or copy the `pre-push.sample` file to `.github/hooks/pre-push`
+
+## Deployment
+
+### Staging
+
+The `main` branch is automatically deployed with each commit. The deployed API Swagger docs can be viewed at
+[https://api.staging.caselaw.nationalarchives.gov.uk/docs](https://api.staging.caselaw.nationalarchives.gov.uk/docs)
+
+### Production
+
+To deploy to production:
+
+1. Create a [new release](https://github.com/nationalarchives/ds-caselaw-pprivileged-api/releases).
+2. Set the tag and release name to `vX.Y.Z`, following semantic versioning.
+3. Publish the release.
+4. Automated workflow will then force-push that release to the `production` branch, which will then be deployed to the
+   production environment.
+
+The production Swagger API docs are at
+[https://api.caselaw.nationalarchives.gov.uk/docs](https://api.caselaw.nationalarchives.gov.uk/docs)


### PR DESCRIPTION
Add a Github action to push the code to production when a new `latest` tag is
created.

Update the README with release process instructions.