### PR TITLE
Correct an apostrophe which had been expanded into an entity reference

### DIFF
--- a/src/openapi_server/apis/reading_api.py
+++ b/src/openapi_server/apis/reading_api.py
@@ -54,7 +54,7 @@ async def get_document_by_uri(
         200: {"description": "OK"},
     },
     tags=["Reading"],
-    summary="Gets the document&#39;s metadata",
+    summary="Gets the document's metadata",
     response_model_by_alias=True,
 )
 async def judgment_uri_metadata_get(


### PR DESCRIPTION
<img width="712" alt="Screenshot 2022-08-30 at 10 05 54" src="https://user-images.githubusercontent.com/1089521/187397089-329b2dcd-e62e-4c81-877c-c6c0b10d951f.png">
