### PR TITLE
List unpublished documents

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -41,3 +41,4 @@ requests-toolbelt==0.9.1
 urllib3==1.26.8
 
 pytest==7.1.2
+lxml==4.9.1

--- a/src/openapi_server/apis/reading_api.py
+++ b/src/openapi_server/apis/reading_api.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 
-from typing import Dict, List  # noqa: F401
+import lxml.etree
+from typing import Dict, List, Any  # noqa: F401
 
 from caselawclient.Client import MarklogicAPIError
 from fastapi import (  # noqa: F401
@@ -13,6 +14,7 @@ from fastapi import (  # noqa: F401
     Path,
     Query,
     Response,
+    Request,
     Security,
     status,
 )
@@ -21,7 +23,24 @@ from openapi_server.security_api import get_token_basic
 
 from openapi_server.connect import client_for_basic_auth
 
+from requests_toolbelt.multipart import decoder
+
 router = APIRouter()
+
+
+def decode_multipart_response(response):
+    multipart_data = decoder.MultipartDecoder.from_response(response)
+    return multipart_data.parts[0].text
+
+
+def unpack_list(xpath_list):
+    # XPath expressions are often lists; often they should only have one value, or none.
+    # Break if there are multiple values, or unpack the list.
+    assert len(xpath_list) <= 1
+    if xpath_list:
+        return xpath_list[0]
+    else:
+        return None
 
 
 @router.get(
@@ -46,3 +65,63 @@ async def get_document_by_uri(
         response.status_code = 404
         return "Resource not found."
     return Response(status_code=200, content=judgment, media_type="application/xml")
+
+@router.get(
+    "/list/unpublished",
+    responses={
+        200: {"description": "A list of URLs of unpublished documents in JSON format"},
+    },
+    tags=["Reading"],
+    summary="Get a list of unpublished URLs",
+    response_model_by_alias=True,
+)
+async def list_unpublished_get_get(
+    request: Request,
+    response: Response,
+    token_basic: TokenModel = Security(get_token_basic),
+    page: int = 1,  # should not be 0
+) -> Any:
+    """Unless the client has `read_unpublished_documents` permission,
+    then only metadata for published documents are accessible."""
+    client = client_for_basic_auth(token_basic)
+    if not client.user_can_view_unpublished_judgments():
+        response.status_code = 403
+        return {"status": "Not allowed to see unpublished documents"}
+
+    response = client.advanced_search(
+        page=page,
+        show_unpublished=True,
+        only_unpublished=True,
+    )
+
+    xml = decode_multipart_response(response)
+
+    content_type = request.headers.get("Content-Type") or ""
+    if "application/xml" in content_type:
+        return Response(status_code=200, content=xml, media_type="application/xml")
+
+    root = lxml.etree.fromstring(xml)
+    namespaces = {
+        "search": "http://marklogic.com/appservices/search",
+        "uk": "https://caselaw.nationalarchives.gov.uk/akn",
+        "akn": "http://docs.oasis-open.org/legaldocml/ns/akn/3.0",
+    }
+
+    results = []
+
+    for result in root.xpath("//search:result", namespaces=namespaces):
+        data = {}
+        data["raw_uri"] = unpack_list(result.xpath("./@uri"))
+        data["uri"] = data['raw_uri'].partition('.xml')[0]
+        data["date"] = unpack_list(
+            result.xpath(".//akn:FRBRdate/@date", namespaces=namespaces)
+        )
+        data["name"] = unpack_list(
+            result.xpath(".//akn:FRBRname/@value", namespaces=namespaces)
+        )
+        data["neutral"] = unpack_list(
+            result.xpath(".//uk:cite/text()", namespaces=namespaces)
+        )
+        results.append(data)
+
+    return {"status": "ok", "data": results}

--- a/src/openapi_server/apis/reading_api.py
+++ b/src/openapi_server/apis/reading_api.py
@@ -66,6 +66,7 @@ async def get_document_by_uri(
         return "Resource not found."
     return Response(status_code=200, content=judgment, media_type="application/xml")
 
+
 @router.get(
     "/list/unpublished",
     responses={
@@ -112,7 +113,7 @@ async def list_unpublished_get_get(
     for result in root.xpath("//search:result", namespaces=namespaces):
         data = {}
         data["raw_uri"] = unpack_list(result.xpath("./@uri"))
-        data["uri"] = data['raw_uri'].partition('.xml')[0]
+        data["uri"] = data["raw_uri"].partition(".xml")[0]
         data["date"] = unpack_list(
             result.xpath(".//akn:FRBRdate/@date", namespaces=namespaces)
         )

--- a/tests/test_reading_api.py
+++ b/tests/test_reading_api.py
@@ -27,3 +27,66 @@ def test_get_not_found(mocked_client):
     mocked_client.return_value.get_judgment_xml.assert_called_with("bad_uri")
     assert response.status_code == 404
     assert "Resource not found." in response.text
+
+@patch("openapi_server.apis.reading_api.client_for_basic_auth")
+def test_get_list_unpublished_bad_auth(mocked_client):
+    mocked_client.return_value.user_can_view_unpublished_judgments.return_value = False
+    response = TestClient(app).request(
+        "GET", "/list/unpublished", auth=("user", "pass")
+    )
+    assert response.status_code == 403
+    assert "Not allowed" in response.text
+
+
+@patch("openapi_server.apis.reading_api.client_for_basic_auth")
+def test_get_list_unpublished(mocked_client):
+    mocked_client.return_value.user_can_view_unpublished_judgments.return_value = True
+    advanced_search = mocked_client.return_value.advanced_search.return_value
+    advanced_search.text = "true"
+    advanced_search.headers = {
+        "content-type": "multipart/mixed; boundary=6bfe89fc4493c0e3"
+    }
+    advanced_search.content = b'\r\n--6bfe89fc4493c0e3\r\nContent-Type: application/xml\r\nX-Primitive: element()\r\nX-Path: /*:response\r\n\r\n<search:response snippet-format="empty-snippet" total="32" start="1" page-length="10" selected="include" xmlns:search="http://marklogic.com/appservices/search">\n  <search:result index="1" uri="/ewhc/scco/2022/1775.xml" path="fn:doc(&quot;/ewhc/scco/2022/1775.xml&quot;)" score="0" confidence="0" fitness="0">\n    <search:snippet/>\n    <search:extracted kind="element"><FRBRdate date="2022-06-30" name="judgment" xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0"/><FRBRname value="REGINA v NOT REAL NAME" xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0"/><uk:cite xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn">[2000] EWHC 1</uk:cite></search:extracted>\n  </search:result></search:response>'  # noqa: E501
+
+    response = TestClient(app).request(
+        "GET", "/list/unpublished", auth=("user", "pass")
+    )
+    mocked_client.return_value.advanced_search.assert_called_with(
+        page=1,
+        show_unpublished=True,
+        only_unpublished=True,
+    )
+    assert response.status_code == 200
+    assert "ok" in response.text
+    judgment = response.json()["data"][0]
+    assert judgment["name"] == "REGINA v NOT REAL NAME"
+    assert judgment["neutral"] == "[2000] EWHC 1"
+    assert judgment["date"] == "2022-06-30"
+    assert judgment["uri"] == "/ewhc/scco/2022/1775"
+    assert judgment["raw_uri"] == "/ewhc/scco/2022/1775.xml"
+
+
+@patch("openapi_server.apis.reading_api.client_for_basic_auth")
+def test_get_list_unpublished_xml(mocked_client):
+    mocked_client.return_value.user_can_view_unpublished_judgments.return_value = True
+    advanced_search = mocked_client.return_value.advanced_search.return_value
+    advanced_search.text = "true"
+    advanced_search.headers = {
+        "content-type": "multipart/mixed; boundary=6bfe89fc4493c0e3"
+    }
+    advanced_search.content = b"\r\n--6bfe89fc4493c0e3\r\nContent-Type: application/xml\r\nX-Primitive: element()\r\nX-Path: /*:response\r\n\r\n<whatever></whatever>"  # noqa: E501
+
+    response = TestClient(app).request(
+        "GET",
+        "/list/unpublished?page=6",
+        auth=("user", "pass"),
+        headers={"Content-Type": "application/xml"},
+    )
+    mocked_client.return_value.advanced_search.assert_called_with(
+        page=6,
+        show_unpublished=True,
+        only_unpublished=True,
+    )
+    assert response.status_code == 200
+    assert "whatever" in response.text
+    assert "application/xml" == response.headers.get("Content-Type")

--- a/tests/test_reading_api.py
+++ b/tests/test_reading_api.py
@@ -1,10 +1,19 @@
 # coding: utf-8
 from unittest.mock import patch, Mock
+from unittest import TestCase
 
 from caselawclient.Client import MarklogicResourceNotFoundError
 
 from fastapi.testclient import TestClient
 from openapi_server.main import app
+from openapi_server.apis.reading_api import unpack_list
+
+
+def test_unpack_list():
+    assert unpack_list([1]) == 1
+    assert unpack_list([]) is None
+    with TestCase().assertRaises(AssertionError):
+        unpack_list([1, 1])
 
 
 @patch("openapi_server.apis.reading_api.client_for_basic_auth")
@@ -28,6 +37,7 @@ def test_get_not_found(mocked_client):
     assert response.status_code == 404
     assert "Resource not found." in response.text
 
+
 @patch("openapi_server.apis.reading_api.client_for_basic_auth")
 def test_get_list_unpublished_bad_auth(mocked_client):
     mocked_client.return_value.user_can_view_unpublished_judgments.return_value = False
@@ -46,7 +56,7 @@ def test_get_list_unpublished(mocked_client):
     advanced_search.headers = {
         "content-type": "multipart/mixed; boundary=6bfe89fc4493c0e3"
     }
-    advanced_search.content = b'\r\n--6bfe89fc4493c0e3\r\nContent-Type: application/xml\r\nX-Primitive: element()\r\nX-Path: /*:response\r\n\r\n<search:response snippet-format="empty-snippet" total="32" start="1" page-length="10" selected="include" xmlns:search="http://marklogic.com/appservices/search">\n  <search:result index="1" uri="/ewhc/scco/2022/1775.xml" path="fn:doc(&quot;/ewhc/scco/2022/1775.xml&quot;)" score="0" confidence="0" fitness="0">\n    <search:snippet/>\n    <search:extracted kind="element"><FRBRdate date="2022-06-30" name="judgment" xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0"/><FRBRname value="REGINA v NOT REAL NAME" xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0"/><uk:cite xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn">[2000] EWHC 1</uk:cite></search:extracted>\n  </search:result></search:response>'  # noqa: E501
+    advanced_search.content = b'\r\n--6bfe89fc4493c0e3\r\nContent-Type: application/xml\r\nX-Primitive: element()\r\nX-Path: /*:response\r\n\r\n<search:response snippet-format="empty-snippet" total="32" start="1" page-length="10" selected="include" xmlns:search="http://marklogic.com/appservices/search">\n  <search:result index="1" uri="/ewhc/scco/2022/1775.xml" path="fn:doc(&quot;/ewhc/scco/2022/1775.xml&quot;)" score="0" confidence="0" fitness="0">\n    <search:snippet/>\n    <search:extracted kind="element"><FRBRdate date="2022-06-30" name="judgment" xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0"/><FRBRname xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0"/><uk:cite xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn">[2000] EWHC 1</uk:cite></search:extracted>\n  </search:result></search:response>'  # noqa: E501
 
     response = TestClient(app).request(
         "GET", "/list/unpublished", auth=("user", "pass")
@@ -59,7 +69,7 @@ def test_get_list_unpublished(mocked_client):
     assert response.status_code == 200
     assert "ok" in response.text
     judgment = response.json()["data"][0]
-    assert judgment["name"] == "REGINA v NOT REAL NAME"
+    assert judgment["name"] is None  # element deleted
     assert judgment["neutral"] == "[2000] EWHC 1"
     assert judgment["date"] == "2022-06-30"
     assert judgment["uri"] == "/ewhc/scco/2022/1775"


### PR DESCRIPTION
We provide the raw XML and a JSON version of the data.

Should the XML handling be in the custom-client-api?