### PR TITLE
Remove get/set metadata endpoint stubs

### DIFF
--- a/src/openapi_server/apis/reading_api.py
+++ b/src/openapi_server/apis/reading_api.py
@@ -46,21 +46,3 @@ async def get_document_by_uri(
         response.status_code = 404
         return "Resource not found."
     return Response(status_code=200, content=judgment, media_type="application/xml")
-
-
-@router.get(
-    "/metadata/{judgmentUri:path}",
-    responses={
-        200: {"description": "OK"},
-    },
-    tags=["Reading"],
-    summary="Gets the document's metadata",
-    response_model_by_alias=True,
-)
-async def judgment_uri_metadata_get(
-    judgmentUri: str = Path(None, description=""),
-    token_basic: TokenModel = Security(get_token_basic),
-) -> None:
-    """Unless the client has `read_unpublished_documents` permission,
-    then only metadata for published documents are accessible."""
-    ...

--- a/src/openapi_server/apis/writing_api.py
+++ b/src/openapi_server/apis/writing_api.py
@@ -119,24 +119,6 @@ async def judgment_uri_lock_delete(
 
 
 @router.patch(
-    "/metadata/{judgmentUri:path}",
-    responses={
-        200: {"description": "OK"},
-    },
-    tags=["Writing"],
-    summary="Set document properties",
-    response_model_by_alias=True,
-)
-async def judgment_uri_metadata_patch(
-    judgmentUri: str = Path(None, description=""),
-    token_basic: TokenModel = Security(get_token_basic),
-    annotation: Optional[str] = None,
-    unlock: bool = False,
-) -> None:
-    ...
-
-
-@router.patch(
     "/judgment/{judgmentUri:path}",
     responses={
         200: {

--- a/tests/test_reading_api.py
+++ b/tests/test_reading_api.py
@@ -1,7 +1,6 @@
 # coding: utf-8
 from unittest.mock import patch, Mock
 
-import pytest
 from caselawclient.Client import MarklogicResourceNotFoundError
 
 from fastapi.testclient import TestClient
@@ -28,22 +27,3 @@ def test_get_not_found(mocked_client):
     mocked_client.return_value.get_judgment_xml.assert_called_with("bad_uri")
     assert response.status_code == 404
     assert "Resource not found." in response.text
-
-
-@pytest.mark.xfail(reason="Test is TODO")
-def test_judgment_uri_metadata_get(client: TestClient):
-    """Test case for judgment_uri_metadata_get
-
-    Gets the document's metadata
-    """
-
-    headers = {
-        "Authorization": "BasicZm9vOmJhcg==",
-    }
-    response = client.request(
-        "GET",
-        "/{judgmentUri}/metadata".format(judgmentUri="judgment_uri_example"),
-        headers=headers,
-    )
-
-    assert response.status_code == 200


### PR DESCRIPTION
It was decided that we might not need the metadata endpoints since we have full XML rewriting capability -- we are removing them for now until we know we need them so they're removed from the documentation.