### PR TITLE
Bump ds-caselaw-marklogic-api-client to v4.10.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -30,8 +30,7 @@ uvloop==0.16.0
 watchgod==0.8.2
 websockets==10.3
 
-ds-caselaw-marklogic-api-client>=4.9.2
-# ../ds-caselaw-custom-api-client
+ds-caselaw-marklogic-api-client>=4.10.0
 certifi==2021.10.8
 # charset-normalizer==2.1.0
 django-environ==0.8.1


### PR DESCRIPTION
This fixes an issue with privilege checking - users who were granted access to view unpublished judgments were not able to view them.