### PR TITLE
Bump starette and fastapi (mutual dependencies)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,12 +5,13 @@ async-generator==1.10
 click==8.1.3
 dnspython==2.2.1
 email-validator==1.3.0
-fastapi==0.81.0
+fastapi==0.88.0
 graphene==3.1.1
 graphql-core==3.2.3
 graphql-relay==3.2.0
 h11==0.14.0
 httptools==0.5.0
+httpx==0.23.1
 itsdangerous==2.1.2
 Jinja2==3.1.2
 MarkupSafe==2.1.1
@@ -22,7 +23,7 @@ python-multipart==0.0.5
 PyYAML==6.0.0
 Rx==1.6.1
 six==1.16.0
-starlette==0.19.1
+starlette==0.22.0
 typing-extensions==4.4.0
 ujson==5.6.0
 uvicorn==0.20.0


### PR DESCRIPTION
It looks like there's a new dependency for one of these on httpx, so added the most recent version of that to requirements.txt

It'd be nice to get all these different repos working with poetry or similar.