### PR TITLE
Bump MarkLogic API client to 5.1.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ uvloop==0.17.0
 watchgod==0.8.2
 websockets==10.4
 
-ds-caselaw-marklogic-api-client>=4.10.0
+ds-caselaw-marklogic-api-client>=5.1.4
 certifi==2022.12.7
 # charset-normalizer==2.1.0
 django-environ==0.9.0


### PR DESCRIPTION
There are no significant changes, this is just making sure we're keeping up to date with recent releases.