### PR TITLE
Better Enrichment Errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Python >= 3.8
 
 ## Installation & Usage
 
-Ensure that the MARKLOGIC_API_CLIENT_HOST environment is set to point at the Marklogic server.
+Ensure that the `MARKLOGIC_API_CLIENT_HOST` environment is set to point at the Marklogic server.
 
 Consider using a virtual environment via ```virtualenv -p `which python` ```
 Consider importing prerequisites via `pip install -r requirements.txt`

--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@ Python >= 3.8
 
 ## Installation & Usage
 
+Ensure that the MARKLOGIC_API_CLIENT_HOST environment is set to point at the Marklogic server.
+
+Consider using a virtual environment via ```virtualenv -p `which python` ```
+Consider importing prerequisites via `pip install -r requirements.txt`
+
 To run the server, run `script/server`; open `http://localhost:8080/` in a browser
 
 ## Documentation

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ uvloop==0.17.0
 watchgod==0.8.2
 websockets==10.4
 
-ds-caselaw-marklogic-api-client>=5.1.4
+ds-caselaw-marklogic-api-client>=5.2.0
 certifi==2022.12.7
 # charset-normalizer==2.1.0
 django-environ==0.9.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [flake8]
 max-line-length = 120
 exclude = .tox,.git,*/migrations/*,*/static/CACHE/*,docs,node_modules,venv
-ignore = I001, I002, I003, I004, I005
+extend-ignore = I001, I002, I003, I004, I005, W503
 
 [pycodestyle]
 max-line-length = 120

--- a/src/openapi_server/apis/reading_api.py
+++ b/src/openapi_server/apis/reading_api.py
@@ -3,7 +3,6 @@
 import lxml.etree
 from typing import Dict, List, Any  # noqa: F401
 
-from caselawclient.Client import MarklogicAPIError
 from fastapi import (  # noqa: F401
     APIRouter,
     Body,
@@ -24,6 +23,8 @@ from openapi_server.security_api import get_token_basic
 from openapi_server.connect import client_for_basic_auth
 
 from requests_toolbelt.multipart import decoder
+
+from .utils import error_handling
 
 router = APIRouter()
 
@@ -60,12 +61,9 @@ async def get_document_by_uri(
     judgmentUri: str = Path(None, description=""),
     token_basic: TokenModel = Security(get_token_basic),
 ):
-    try:
+    with error_handling():
         client = client_for_basic_auth(token_basic)
         judgment = client.get_judgment_xml(judgmentUri)
-    except MarklogicAPIError:
-        response.status_code = 404
-        return "Resource not found."
     return Response(status_code=200, content=judgment, media_type="application/xml")
 
 

--- a/src/openapi_server/apis/reading_api.py
+++ b/src/openapi_server/apis/reading_api.py
@@ -36,7 +36,9 @@ def decode_multipart_response(response):
 def unpack_list(xpath_list):
     # XPath expressions are often lists; often they should only have one value, or none.
     # Break if there are multiple values, or unpack the list.
-    assert len(xpath_list) <= 1
+    assert (
+        len(xpath_list) <= 1
+    ), f"There should only be one response, but there were {len(xpath_list)}: \n {xpath_list}"
     if xpath_list:
         return xpath_list[0]
     else:
@@ -115,7 +117,9 @@ async def list_unpublished_get_get(
         data["raw_uri"] = unpack_list(result.xpath("./@uri"))
         data["uri"] = data["raw_uri"].partition(".xml")[0]
         data["date"] = unpack_list(
-            result.xpath(".//akn:FRBRdate/@date", namespaces=namespaces)
+            result.xpath(
+                ".//akn:FRBRdate[@name='judgment']/@date", namespaces=namespaces
+            )
         )
         data["name"] = unpack_list(
             result.xpath(".//akn:FRBRname/@value", namespaces=namespaces)

--- a/src/openapi_server/apis/utils.py
+++ b/src/openapi_server/apis/utils.py
@@ -1,0 +1,21 @@
+from fastapi import HTTPException
+from contextlib import contextmanager
+
+
+@contextmanager
+def error_handling():
+    try:
+        yield
+
+    except BaseException as e:
+        print(f"EXCEPTION {e}")
+        return error_response(e)
+
+
+def error_response(e):
+    """provide a uniform error Response"""
+
+    print("???")
+    print(e)
+    # If the Exception one about validation, output the entire failure message, otherwise don't.
+    raise HTTPException(status_code=e.status_code, detail=e.default_message)

--- a/src/openapi_server/apis/utils.py
+++ b/src/openapi_server/apis/utils.py
@@ -2,7 +2,7 @@ from fastapi import HTTPException
 from contextlib import contextmanager
 from caselawclient.Client import MarklogicValidationFailedError, MarklogicAPIError
 import lxml.etree
-import traceback
+import logging
 
 
 @contextmanager
@@ -17,10 +17,7 @@ def error_handling():
 
 def error_response(e):
     """provide a uniform error Response"""
-    print("### Error contents:")
-    print(e)
-    print("### End of error")
-
+    logging.warning(e)
     if isinstance(e, MarklogicValidationFailedError):
         root = lxml.etree.fromstring(e.response.content)
         error_message = root.xpath(
@@ -32,9 +29,9 @@ def error_response(e):
         raise HTTPException(status_code=e.status_code, detail=e.default_message)
     else:
         # presumably a Python error, not a Marklogic one
-        print("### Traceback")
-        traceback.print_exc()
-        print("### End traceback")
+        logging.exception(
+            "A Python error in the privileged API occurred whilst making a request to Marklogic"
+        )
         raise HTTPException(
             status_code=500, detail="An unknown error occurred outside of Marklogic."
         )

--- a/tests/test_reading_api.py
+++ b/tests/test_reading_api.py
@@ -35,7 +35,7 @@ def test_get_not_found(mocked_client):
     )
     mocked_client.return_value.get_judgment_xml.assert_called_with("bad_uri")
     assert response.status_code == 404
-    assert "Resource not found." in response.text
+    assert "No resource with that name" in response.text
 
 
 @patch("openapi_server.apis.reading_api.client_for_basic_auth")

--- a/tests/test_status_api.py
+++ b/tests/test_status_api.py
@@ -18,7 +18,10 @@ def test_get_status_no_such_user(mocked_client=None):
     )
     response = TestClient(app).request("GET", "/status", auth=("user", "pass"))
     assert response.status_code == 401
-    assert response.content == b'{"detail":"/status: user Unauthorised"}'
+    assert (
+        response.content
+        == b'{"detail":"Your credentials are not valid, or you did not provide any by basic authentication"}'
+    )
     mocked_client.return_value.user_can_view_unpublished_judgments.assert_called_with(
         "user"
     )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,93 @@
+from openapi_server.apis.utils import error_handling
+from fastapi.exceptions import HTTPException
+from caselawclient.Client import (
+    MarklogicUnauthorizedError,
+    MarklogicValidationFailedError,
+)
+from unittest.mock import Mock
+import pytest
+
+
+def test_error_handling_no_exception():
+    def example():
+        with error_handling():
+            return 4
+
+    assert example() == 4
+
+
+def test_error_handling_python_error(caplog):
+    """
+    Given you will get a standard Python exception
+    When using error_handling
+    Then the error response:
+      contains a very generic error with no contents
+      has a relevant status code
+    And outputs the message and traceback to the logs
+    """
+
+    def example():
+        with error_handling():
+            1 / 0
+
+    with pytest.raises(HTTPException) as ex:
+        example()
+    assert ex.value.detail == "An unknown error occurred outside of Marklogic."
+    assert ex.value.status_code == 500
+    assert "division by zero" in caplog.text
+    assert "1 / 0" in caplog.text
+
+
+def test_validation_error(caplog):
+    """
+    Given you will get a validation MarklogicAPIError exception
+    When using error_handling
+    Then the error response:
+      contains the marklogic error message
+      is the default message
+      has a relevant status code
+    And outputs the message to the logs
+    """
+
+    def example():
+        e = MarklogicValidationFailedError("error_msg")
+        e.response = Mock()
+        e.response.content = b'<error-response xmlns="http://marklogic.com/xdmp/error"><message>a message from marklogic</message></error-response>'  # noqa:E501
+
+        with error_handling():
+            raise e
+
+    with pytest.raises(HTTPException) as ex:
+        example()
+
+    assert ex.value.detail == "a message from marklogic"
+    assert ex.value.status_code == 422
+    assert "error_msg" in caplog.text
+
+
+def test_non_validation_error(caplog):
+    """
+    Given you will get a non-validation MarklogicAPIError exception
+    When using error_handling
+    Then the error response:
+      does not contain the marklogic error message
+      is the default message
+      has a relevant status code
+    And outputs the message to the logs
+    """
+
+    def example():
+        e = MarklogicUnauthorizedError("error_msg")
+        e.response = Mock()
+        e.response.content = b'<error-response xmlns="http://marklogic.com/xdmp/error"><message>a message from marklogic</message></error-response>'  # noqa:E501
+
+        with error_handling():
+            raise e
+
+    with pytest.raises(HTTPException) as ex:
+        example()
+
+    assert "a message from marklogic" not in ex.value.detail
+    assert "Your credentials are not valid" in ex.value.detail
+    assert ex.value.status_code == 401
+    assert "error_msg" in caplog.text

--- a/tests/test_writing_api.py
+++ b/tests/test_writing_api.py
@@ -223,6 +223,6 @@ def test_judgment_validation_fail(mocked_client):
     )
     assert response.status_code == 422
     assert (
-        response.text
-        == '{"detail":"The XML document did not validate according to the schema"}'
+        response.json()["detail"]
+        == "The XML document did not validate according to the schema"
     )


### PR DESCRIPTION
Will require new version of custom-api-client.

We move almost all error handling to one place, using

```python
from .utils import errorhandling()

with errorhandling():
     # code we expect to raise MarkLogic errors
```

to catch the exceptions and handle them appropriately. 
[maybe we should just raise non MarkLogic errors?]

This is so that we can identify errors where we can usefully and safelyreveal more information to the end user about what went wrong (mostly, validation)

We also print more diagnostic information to the logs, which will help diagnose current and future problems.
