### PR TITLE
Allow showing unpublished judgments if the user is allowed to.

### DIFF
--- a/src/openapi_server/apis/reading_api.py
+++ b/src/openapi_server/apis/reading_api.py
@@ -63,7 +63,12 @@ async def get_document_by_uri(
 ):
     with error_handling():
         client = client_for_basic_auth(token_basic)
-        judgment = client.get_judgment_xml(judgmentUri)
+        can_view_unpublished = client.user_can_view_unpublished_judgments(
+            token_basic.username
+        )
+        judgment = client.get_judgment_xml(
+            judgmentUri, show_unpublished=can_view_unpublished
+        )
     return Response(status_code=200, content=judgment, media_type="application/xml")
 
 

--- a/tests/test_reading_api.py
+++ b/tests/test_reading_api.py
@@ -19,8 +19,11 @@ def test_unpack_list():
 @patch("openapi_server.apis.reading_api.client_for_basic_auth")
 def test_get_success(mocked_client):
     mocked_client.return_value.get_judgment_xml.return_value = b"<judgment></judgment>"
+    mocked_client.return_value.user_can_view_unpublished_judgments.return_value = True
     response = TestClient(app).request("GET", "/judgment/uri", auth=("user", "pass"))
-    mocked_client.return_value.get_judgment_xml.assert_called_with("uri")
+    mocked_client.return_value.get_judgment_xml.assert_called_with(
+        "uri", show_unpublished=True
+    )
     assert response.status_code == 200
     assert "<judgment>" in response.text
 
@@ -30,10 +33,13 @@ def test_get_not_found(mocked_client):
     mocked_client.return_value.get_judgment_xml.side_effect = Mock(
         side_effect=MarklogicResourceNotFoundError()
     )
+    mocked_client.return_value.user_can_view_unpublished_judgments.return_value = True
     response = TestClient(app).request(
         "GET", "/judgment/bad_uri", auth=("user", "pass")
     )
-    mocked_client.return_value.get_judgment_xml.assert_called_with("bad_uri")
+    mocked_client.return_value.get_judgment_xml.assert_called_with(
+        "bad_uri", show_unpublished=True
+    )
     assert response.status_code == 404
     assert "No resource with that name" in response.text
 


### PR DESCRIPTION
Rather complicated by the fact that we consider whether the user is allowed to see the document in python not MarkLogic.

Notably, if a user can lock a document, then they'll (probably -- not acually tested) be able to read the data anyway.