### PR TITLE
Set Cache Headers

### DIFF
--- a/src/openapi_server/main.py
+++ b/src/openapi_server/main.py
@@ -10,7 +10,7 @@
 """
 
 
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
 from openapi_server.apis.reading_api import router as ReadingApiRouter
 from openapi_server.apis.status_api import router as StatusApiRouter
 from openapi_server.apis.writing_api import router as WritingApiRouter
@@ -24,3 +24,12 @@ app = FastAPI(
 app.include_router(ReadingApiRouter)
 app.include_router(StatusApiRouter)
 app.include_router(WritingApiRouter)
+
+
+@app.middleware("http")
+async def add_cache_control_header(request: Request, call_next):
+    """Do not cache the API, to avoid clients saving stale data.
+    Code based on https://fastapi.tiangolo.com/tutorial/middleware/"""
+    response = await call_next(request)
+    response.headers["Cache-Control"] = "no-store"
+    return response


### PR DESCRIPTION
We were having problems with caching leading to the Enrichment service being sent stale judgments and saving back modified versions of those stale judgments.

See also https://github.com/dxw/dalmatian-config/pull/610 and https://github.com/dxw/dalmatian-config/pull/611