### PR TITLE
Bump versions as requested by dependabot

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ async-generator==1.10
 click==8.1.3
 dnspython==2.3.0
 email-validator==1.3.1
-fastapi==0.90.0
+fastapi==0.93.0
 graphene==3.2.1
 graphql-core==3.2.3
 graphql-relay==3.2.0
@@ -15,15 +15,15 @@ httpx==0.23.3
 itsdangerous==2.1.2
 Jinja2==3.1.2
 MarkupSafe==2.1.2
-orjson==3.8.5
+orjson==3.8.6
 promise==2.3
-pydantic==1.10.4
+pydantic==1.10.5
 python-dotenv==0.21.1
 python-multipart==0.0.5
 PyYAML==6.0.0
 Rx==3.2.0
 six==1.16.0
-starlette==0.22.0
+starlette==0.25.0
 typing-extensions==4.5.0
 ujson==5.7.0
 uvicorn==0.20.0


### PR DESCRIPTION
The version of starette is 0.25 not 0.24 because fastapi needs it; it's possible there'll be additional dependabot prs after this, but they're all stalled due to being edited to make sure they're signed... or something.