### PR TITLE
Delete starlette subdepdency pin

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ async-generator==1.10
 click==8.1.3
 dnspython==2.3.0
 email-validator==2.0.0.post2
-fastapi==0.96.0
+fastapi==0.93.0
 graphene==3.2.2
 graphql-core==3.2.3
 graphql-relay==3.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ async-generator==1.10
 click==8.1.3
 dnspython==2.3.0
 email-validator==2.0.0.post2
-fastapi==0.93.0
+fastapi==0.96.0
 graphene==3.2.2
 graphql-core==3.2.3
 graphql-relay==3.2.0
@@ -23,7 +23,6 @@ python-multipart==0.0.6
 PyYAML==6.0.0
 Rx==3.2.0
 six==1.16.0
-starlette==0.25.0
 typing-extensions==4.6.2
 ujson==5.7.0
 uvicorn==0.22.0


### PR DESCRIPTION
Changes:
- Delete starlette subdepdency pin.

Reason:
- Dependabot wanted to update both separetly, but each PR (https://github.com/nationalarchives/ds-caselaw-privileged-api/pull/157 and https://github.com/nationalarchives/ds-caselaw-privileged-api/pull/155) failed due to the dependency fastapi has on starlette (this also happended previously on this repo or another).

Decided to remove starlette pinning and just let fastapi install the version it wants since we only use it for fastapi.

Note: havent bumped fastapi to 0.96.0 from 0.93.0 since there are some breaking changes.