### PR TITLE
Loosen pydantic requirement and bump fastapi to 0.100

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ async-generator==1.10
 click==8.1.6
 dnspython==2.4.1
 email-validator==2.0.0.post2
-fastapi==0.93.0
+fastapi==0.100.0
 graphene==3.3
 graphql-core==3.2.3
 graphql-relay==3.2.0
@@ -17,7 +17,7 @@ Jinja2==3.1.2
 MarkupSafe==2.1.3
 orjson==3.9.2
 promise==2.3
-pydantic==1.10.12
+pydantic>=2.0.3
 python-dotenv==1.0.0
 python-multipart==0.0.6
 PyYAML==6.0.1

--- a/src/openapi_server/apis/reading_api.py
+++ b/src/openapi_server/apis/reading_api.py
@@ -58,7 +58,7 @@ def unpack_list(xpath_list):
 )
 async def get_document_by_uri(
     response: Response,
-    judgmentUri: str = Path(None, description=""),
+    judgmentUri: str,
     token_basic: TokenModel = Security(get_token_basic),
 ):
     with error_handling():

--- a/src/openapi_server/apis/writing_api.py
+++ b/src/openapi_server/apis/writing_api.py
@@ -49,7 +49,7 @@ router = APIRouter()
 )
 async def judgment_uri_lock_get(
     response: Response,
-    judgmentUri: str = Path(None, description=""),
+    judgmentUri: str,
     token_basic: TokenModel = Security(get_token_basic),
 ):
     client = client_for_basic_auth(token_basic)
@@ -81,7 +81,7 @@ async def judgment_uri_lock_get(
 )
 async def judgment_uri_lock_put(
     response: Response,
-    judgmentUri: str = Path(None, description=""),
+    judgmentUri: str,
     token_basic: TokenModel = Security(get_token_basic),
     expires="0",
 ):
@@ -112,7 +112,7 @@ async def judgment_uri_lock_put(
 )
 async def judgment_uri_lock_delete(
     response: Response,
-    judgmentUri: str = Path(None, description=""),
+    judgmentUri: str,
     token_basic: TokenModel = Security(get_token_basic),
 ):
     client = client_for_basic_auth(token_basic)
@@ -146,7 +146,7 @@ async def judgment_uri_lock_delete(
 async def judgment_uri_patch(
     request: Request,
     response: Response,
-    judgmentUri: str = Path(None, description=""),
+    judgmentUri: str,
     if_match: str = Header(
         None, description="The last known version number of the document"
     ),


### PR DESCRIPTION
These two dependencies need to be in sync; we care about fastapi but not pydantic (I think)

Some point around FastAPI 0.95 our code became incompatible because they tightened up some things -- we're now not allowed default parameters where there's a function parameter coming from a path, mostly because that should never happen (it'd maybe be `""`)