### PR TITLE
Auto-unlock if save_locked_judgment_xml fails and unlock was requested

### DIFF
--- a/src/openapi_server/apis/writing_api.py
+++ b/src/openapi_server/apis/writing_api.py
@@ -161,12 +161,18 @@ async def judgment_uri_patch(  # noqa: PLR0913
         message=annotation if annotation else None,
     )
 
-    with error_handling():
-        client.save_locked_judgment_xml(
-            judgment_uri=judgmentUri,
-            judgment_xml=bytes_body,
-            annotation=rich_annotation,
-        )
+    try:
+        with error_handling():
+            client.save_locked_judgment_xml(
+                judgment_uri=judgmentUri,
+                judgment_xml=bytes_body,
+                annotation=rich_annotation,
+            )
+    except Exception:
+        if unlock:
+            with error_handling():
+                _ml_response = client.checkin_judgment(judgment_uri=judgmentUri)
+        raise
 
     if not unlock:
         response.status_code = 200


### PR DESCRIPTION
The enrichment process has hit a significant error when trying to upload (it's probably not schema-valid) so if it asked to unlock, we should unlock.
