### PR TITLE
Ensure precommit works with saxonche in api client

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,5 @@
+default_language_version:
+  python: "3.12"
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0
@@ -29,7 +31,7 @@ repos:
           [
             "types-requests",
             "types-ujson",
-            "ds-caselaw-marklogic-api-client==17.2.0",
+            "ds-caselaw-marklogic-api-client==27.3.0",
           ]
         files: ^src/
 


### PR DESCRIPTION
We were getting errors like:

ERROR: Could not find a version that satisfies the requirement saxonche<13.0.0,>=12.5.0 (from ds-caselaw-marklogic-api-client) (from versions: none)

when we tried to upgrade the api-client version.