### PR TITLE
[FCL-806] Update latest-tag to work with stricter permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,13 +8,15 @@ jobs:
   run:
     name: Run local action
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
-          persist-credentials: false
+          persist-credentials: true
       - name: Run latest-tag
-        uses: dxw/latest-tag@force-branch
+        uses: EndBug/latest-tag@latest
         with:
-          tag-name: production
+          ref: production
           force-branch: true


### PR DESCRIPTION
This replicates the changes seen in the EUI.

This also swaps from dxw's now-deprecated fork of latest-tag to using the one maintained by EndBug.

## Jira

FCL-806