### PR TITLE
Ensure docker doesn't expose ports externally

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,5 +6,6 @@ services:
     env_file:
       - ./.env
     ports:
-      - "8080:8080"
+      - "127.0.0.1:8080:8080"
+      - "[::1]:8080:8080"
     command: uvicorn openapi_server.main:app --host 0.0.0.0 --port 8080


### PR DESCRIPTION
https://docs.docker.com/engine/network/port-publishing/

> Publishing container ports is insecure by default. Meaning, when you publish a container's ports it becomes available not only to the Docker host, but to the outside world as well.
> If you include the localhost IP address (127.0.0.1, or ::1) with the publish flag, only the Docker host can access the published container port.
> `docker run -p 127.0.0.1:8080:80 -p '[::1]:8080:80' nginx`

A similar warning exists for [ports](https://docs.docker.com/reference/compose-file/services/#ports)
